### PR TITLE
Only consider end when buffer is empty

### DIFF
--- a/src/tink/streams/Accumulator.hx
+++ b/src/tink/streams/Accumulator.hx
@@ -17,17 +17,19 @@ class Accumulator<T> extends StepWise<T> {
   
   override public function next():Future<StreamStep<T>> 
     return
-      if (end != null)
-        Future.sync(end);
-      else
-        switch buffered.shift() {
-          case null:
+      switch buffered.shift() {
+        case null:
+          if (end != null)
+            Future.sync(end);
+          else {
             var ret = Future.trigger();
             waiting.push(ret);
             ret;
-          case v:
-            Future.sync(v);
-        }
+          }
+        case v:
+          Future.sync(v);
+      }
+      
   #if php
   @:native('accumulate')
   #end


### PR DESCRIPTION
Consider this code:
```haxe
var buffer = new tink.streams.Accumulator();
buffer.yield(Data(Success(Noise)));
buffer.yield(Data(Success(Noise)));
buffer.yield(Data(Success(Noise)));
buffer.yield(End);

buffer
	.forEach(function(r) {trace('loop $r'); return true;})
	.handle(function(r) trace('done $r'));
```

Before fix: reach 'done' immediately without looping the items
After fix: reach 'done' after looping the items